### PR TITLE
Fix parsing PARENT_SCOPE as an identifier

### DIFF
--- a/Modules/CMExt.Tokenize.cmake
+++ b/Modules/CMExt.Tokenize.cmake
@@ -53,7 +53,7 @@ function(cme_tokenize cmake_code out_namespace)
   endmacro()
 
   macro(_cme_tokenize_consume_identifier)
-    set(text "${CMAKE_MATCH_0}")
+    string(CONCAT text "${CMAKE_MATCH_0}")
     string(LENGTH "${text}" text_length)
     string(SUBSTRING "${cmake_code}" ${text_length} -1 cmake_code)
     _cme_tokenize_emit_token(Token_Identifier)

--- a/test/CMExt/test_tokenize.cmake
+++ b/test/CMExt/test_tokenize.cmake
@@ -116,6 +116,18 @@ function(test_tokenize_identifiers)
 endfunction()
 
 
+function(test_tokenize_PARENT_SCOPE_identifier)
+
+  set(code "PARENT_SCOPE()")
+
+  cme_tokenize("${code}" tokens)
+
+  assert_cmake_can_parse("${code}")
+  cme_assert([[tokens_parse_error]])
+
+endfunction()
+
+
 function(test_tokenize_nullary_command_invocation)
 
   set(code "foo()\n")

--- a/test/CMExt/test_tokenize.cmake
+++ b/test/CMExt/test_tokenize.cmake
@@ -123,7 +123,10 @@ function(test_tokenize_PARENT_SCOPE_identifier)
   cme_tokenize("${code}" tokens)
 
   assert_cmake_can_parse("${code}")
-  cme_assert([[tokens_parse_error]])
+  cme_assert([[tokens_count EQUAL 3]])
+  assert_token_equals(tokens_1  1   1  "Token_Identifier"  "PARENT_SCOPE")
+  assert_token_equals(tokens_2  1  13  "Token_LeftParen"   "(")
+  assert_token_equals(tokens_3  1  14  "Token_RightParen"  ")")
 
 endfunction()
 


### PR DESCRIPTION
Fix a bug that was introduced in the previous PR (https://github.com/McMartin/CMExt/pull/14).