### PR TITLE
Report syntax errors in cmext-tokenize.cmake

### DIFF
--- a/scripts/cmext-tokenize.cmake
+++ b/scripts/cmext-tokenize.cmake
@@ -50,6 +50,12 @@ function(main)
     )
   endif()
 
+  if(tokens_syntax_error)
+    message(FATAL_ERROR
+      "Syntax error at ${tokens_syntax_error_line},${tokens_syntax_error_column}."
+    )
+  endif()
+
 endfunction()
 
 


### PR DESCRIPTION
This should have been done in https://github.com/McMartin/CMExt/pull/24.